### PR TITLE
docs(requirements): back to current py-cord version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-cord==2.0.0b5
+py-cord
 praw
 dnspython
 PyNaCl


### PR DESCRIPTION
Remove dependency on beta version of py-cord.